### PR TITLE
Don't export graphql types from @automa/common

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,18 @@ module.exports = {
   plugins: ['simple-import-sort'],
   rules: {
     quotes: ['warn', 'single', { avoidEscape: true }],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['@automa/common/src/*'],
+            message:
+              'Please import from `@automa/common`. For types, use `@automa/prisma`.',
+          },
+        ],
+      },
+    ],
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-vars': 'warn',
     '@typescript-eslint/ban-ts-comment': 'off',

--- a/packages/api/src/graphql/resolvers/botInstallations.ts
+++ b/packages/api/src/graphql/resolvers/botInstallations.ts
@@ -1,9 +1,9 @@
 import {
-  BotInstallationResolvers,
   MutationResolvers,
   publicBotFields,
   publicOrgFields,
   QueryResolvers,
+  Resolvers,
 } from '@automa/common';
 
 import { Context } from '../types';
@@ -81,7 +81,7 @@ export const Mutation: MutationResolvers<Context> = {
   },
 };
 
-export const BotInstallation: BotInstallationResolvers<Context> = {
+export const BotInstallation: Resolvers<Context>['BotInstallation'] = {
   org: ({ id }, args, { prisma }) => {
     return prisma.bot_installations
       .findUniqueOrThrow({

--- a/packages/api/src/graphql/resolvers/bots.ts
+++ b/packages/api/src/graphql/resolvers/bots.ts
@@ -2,13 +2,12 @@ import { randomBytes } from 'node:crypto';
 
 import {
   botCreateSchema,
-  BotResolvers,
   botUpdateSchema,
   MutationResolvers,
   publicBotFields,
-  PublicBotResolvers,
   publicOrgFields,
   QueryResolvers,
+  Resolvers,
 } from '@automa/common';
 import { Prisma } from '@automa/prisma';
 
@@ -161,7 +160,7 @@ export const Mutation: MutationResolvers<Context> = {
   },
 };
 
-export const PublicBot: PublicBotResolvers<Context> = {
+export const PublicBot: Resolvers<Context>['PublicBot'] = {
   org: ({ id }, args, { prisma }) => {
     return prisma.bots
       .findUniqueOrThrow({
@@ -206,7 +205,7 @@ export const PublicBot: PublicBotResolvers<Context> = {
   },
 };
 
-export const Bot: BotResolvers<Context> = {
+export const Bot: Resolvers<Context>['Bot'] = {
   org: ({ id }, args, { prisma }) => {
     return prisma.bots
       .findUniqueOrThrow({

--- a/packages/api/src/graphql/resolvers/integrations.ts
+++ b/packages/api/src/graphql/resolvers/integrations.ts
@@ -1,4 +1,4 @@
-import { IntegrationResolvers, QueryResolvers } from '@automa/common';
+import { QueryResolvers, Resolvers } from '@automa/common';
 
 import { Context } from '../types';
 
@@ -20,7 +20,7 @@ export const Query: QueryResolvers<Context> = {
   },
 };
 
-export const Integration: IntegrationResolvers<Context> = {
+export const Integration: Resolvers<Context>['Integration'] = {
   author: ({ id }, args, { prisma }) => {
     return prisma.integrations
       .findUniqueOrThrow({

--- a/packages/api/src/graphql/resolvers/orgs.ts
+++ b/packages/api/src/graphql/resolvers/orgs.ts
@@ -1,4 +1,4 @@
-import { OrgResolvers, QueryResolvers } from '@automa/common';
+import { QueryResolvers, Resolvers } from '@automa/common';
 
 import { Context } from '../types';
 
@@ -17,7 +17,7 @@ export const Query: QueryResolvers<Context> = {
   },
 };
 
-export const Org: OrgResolvers<Context> = {
+export const Org: Resolvers<Context>['Org'] = {
   bot_installations_count: async ({ id }, args, { prisma }) => {
     const {
       _count: { bot_installations: count },

--- a/packages/api/src/graphql/resolvers/repos.ts
+++ b/packages/api/src/graphql/resolvers/repos.ts
@@ -1,4 +1,4 @@
-import { QueryResolvers, RepoResolvers } from '@automa/common';
+import { QueryResolvers, Resolvers } from '@automa/common';
 
 import { Context } from '../types';
 
@@ -36,7 +36,7 @@ export const Query: QueryResolvers<Context> = {
   },
 };
 
-export const Repo: RepoResolvers<Context> = {
+export const Repo: Resolvers<Context>['Repo'] = {
   org: ({ org_id }, args, { prisma }) => {
     return prisma.orgs.findUniqueOrThrow({
       where: {

--- a/packages/api/src/graphql/resolvers/tasks.ts
+++ b/packages/api/src/graphql/resolvers/tasks.ts
@@ -1,9 +1,8 @@
 import {
   MutationResolvers,
   QueryResolvers,
-  TaskItemResolvers,
+  Resolvers,
   taskMessageSchema,
-  TaskResolvers,
 } from '@automa/common';
 import { task_item } from '@automa/prisma';
 
@@ -87,7 +86,7 @@ export const Mutation: MutationResolvers<Context> = {
   },
 };
 
-export const Task: TaskResolvers<Context> = {
+export const Task: Resolvers<Context>['Task'] = {
   org: ({ id }, args, { prisma }) => {
     return prisma.tasks
       .findUniqueOrThrow({
@@ -112,7 +111,7 @@ export const Task: TaskResolvers<Context> = {
   },
 };
 
-export const TaskItem: TaskItemResolvers<Context> = {
+export const TaskItem: Resolvers<Context>['TaskItem'] = {
   actor_user: ({ id }, args, { prisma }) => {
     return prisma.task_items
       .findUniqueOrThrow({

--- a/packages/api/src/graphql/resolvers/users.ts
+++ b/packages/api/src/graphql/resolvers/users.ts
@@ -1,7 +1,7 @@
 import {
   MutationResolvers,
   QueryResolvers,
-  UserResolvers,
+  Resolvers,
   userUpdateSchema,
 } from '@automa/common';
 
@@ -30,7 +30,7 @@ export const Mutation: MutationResolvers<Context> = {
   },
 };
 
-export const User: UserResolvers<Context> = {
+export const User: Resolvers<Context>['User'] = {
   providers: ({ id }, args, { prisma }) => {
     return prisma.users
       .findUniqueOrThrow({

--- a/packages/api/src/routes/api/orgs/_org/integrations/connect/autohooks.ts
+++ b/packages/api/src/routes/api/orgs/_org/integrations/connect/autohooks.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
-import { IntegrationType } from '@automa/common';
+import { integration } from '@automa/prisma';
 
 import { env } from '../../../../../../env';
 
@@ -16,7 +16,7 @@ export default async function (app: FastifyInstance) {
       where: {
         org_id_type: {
           org_id: request.org!.id,
-          type: integration as IntegrationType,
+          type: integration as integration,
         },
       },
     });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,6 @@
 export * from './consts';
 export * from './error';
-export * from './graphql';
+export type { Resolvers, QueryResolvers, MutationResolvers } from './graphql';
 export * from './public';
 export * from './schemas';
 export * from './settings';

--- a/packages/console/.eslintrc.js
+++ b/packages/console/.eslintrc.js
@@ -32,6 +32,18 @@ module.exports = {
         allowEmptyCatch: true,
       },
     ],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['@automa/common/build/*'],
+            message:
+              'Please import from `@automa/common`. For types, use `gql/graphql`.',
+          },
+        ],
+      },
+    ],
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-vars': 'warn',

--- a/packages/console/src/bots/components/Bot/Bot.stories.tsx
+++ b/packages/console/src/bots/components/Bot/Bot.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { BotType } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { BotType } from 'gql/graphql';
 
 import Bot from './Bot';
 

--- a/packages/console/src/bots/components/BotBase/BotBase.stories.tsx
+++ b/packages/console/src/bots/components/BotBase/BotBase.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { BotType } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { BotType } from 'gql/graphql';
 
 import BotBase from './BotBase';
 

--- a/packages/console/src/bots/components/BotInstallation/BotInstallation.stories.tsx
+++ b/packages/console/src/bots/components/BotInstallation/BotInstallation.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { ProviderType } from 'gql/graphql';
 
 import BotInstallation from './BotInstallation';
 

--- a/packages/console/src/bots/components/BotOnboarding/BotOnboarding.stories.tsx
+++ b/packages/console/src/bots/components/BotOnboarding/BotOnboarding.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
+import { ProviderType } from 'gql/graphql';
 
 import BotOnboarding from './BotOnboarding';
 

--- a/packages/console/src/bots/components/PublicBot/PublicBot.stories.tsx
+++ b/packages/console/src/bots/components/PublicBot/PublicBot.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { BotType, ProviderType } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { BotType, ProviderType } from 'gql/graphql';
 
 import PublicBot from './PublicBot';
 

--- a/packages/console/src/bots/filters.ts
+++ b/packages/console/src/bots/filters.ts
@@ -1,5 +1,4 @@
-import { BotType } from '@automa/common';
-
+import { BotType } from 'gql/graphql';
 import { FiltersDefinition, FilterType } from 'shared';
 
 export const publicBotsfilters: FiltersDefinition = {

--- a/packages/console/src/bots/utils.ts
+++ b/packages/console/src/bots/utils.ts
@@ -1,6 +1,6 @@
 import { Alarm, BellRinging } from '@phosphor-icons/react';
 
-import { BotType } from '@automa/common';
+import { BotType } from 'gql/graphql';
 
 export const botTypeDefinition = {
   [BotType.Event]: {

--- a/packages/console/src/bots/views/Bot/Bot.stories.tsx
+++ b/packages/console/src/bots/views/Bot/Bot.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
+import { ProviderType } from 'gql/graphql';
 
 import Bot from './Bot';
 

--- a/packages/console/src/bots/views/Bot/Bot.tsx
+++ b/packages/console/src/bots/views/Bot/Bot.tsx
@@ -4,9 +4,10 @@ import { useMutation, useQuery } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 
-import { BotUpdateInput, botUpdateSchema } from '@automa/common';
+import { botUpdateSchema } from '@automa/common';
 
 import { getFragment } from 'gql';
+import { BotUpdateInput } from 'gql/graphql';
 import {
   Button,
   Flex,

--- a/packages/console/src/bots/views/BotCreate/BotCreate.tsx
+++ b/packages/console/src/bots/views/BotCreate/BotCreate.tsx
@@ -4,9 +4,10 @@ import { useMutation } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Controller, useForm } from 'react-hook-form';
 
-import { BotCreateInput, botCreateSchema, BotType } from '@automa/common';
+import { botCreateSchema } from '@automa/common';
 
 import { getFragment } from 'gql';
+import { BotCreateInput, BotType } from 'gql/graphql';
 import {
   Button,
   Flex,

--- a/packages/console/src/bots/views/PublicBot/PublicBot.stories.tsx
+++ b/packages/console/src/bots/views/PublicBot/PublicBot.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
+import { ProviderType } from 'gql/graphql';
 
 import PublicBot from './PublicBot';
 

--- a/packages/console/src/integrations/components/IntegrationConnectCard/IntegrationConnectCard.stories.tsx
+++ b/packages/console/src/integrations/components/IntegrationConnectCard/IntegrationConnectCard.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { IntegrationType, ProviderType } from '@automa/common';
+import { IntegrationType, ProviderType } from 'gql/graphql';
 
 import IntegrationConnectCard from './IntegrationConnectCard';
 

--- a/packages/console/src/integrations/components/IntegrationConnectCard/IntegrationConnectCard.tsx
+++ b/packages/console/src/integrations/components/IntegrationConnectCard/IntegrationConnectCard.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { IntegrationType } from '@automa/common';
-
+import { IntegrationType } from 'gql/graphql';
 import { Button, Flex, Tooltip, Typography } from 'shared';
 
 import { integrations } from '../../consts';

--- a/packages/console/src/integrations/components/IntegrationConnectCard/types.ts
+++ b/packages/console/src/integrations/components/IntegrationConnectCard/types.ts
@@ -1,6 +1,6 @@
 import { HTMLAttributes } from 'react';
 
-import { IntegrationType } from '@automa/common';
+import { IntegrationType } from 'gql/graphql';
 
 import { Org } from 'orgs';
 

--- a/packages/console/src/integrations/consts.ts
+++ b/packages/console/src/integrations/consts.ts
@@ -1,6 +1,6 @@
 import { FC, SVGProps } from 'react';
 
-import { IntegrationType } from '@automa/common';
+import { IntegrationType } from 'gql/graphql';
 
 import GithubLogo from 'assets/logos/github.svg?react';
 import JiraLogo from 'assets/logos/jira.svg?react';

--- a/packages/console/src/orgs/components/OrgList/OrgList.stories.tsx
+++ b/packages/console/src/orgs/components/OrgList/OrgList.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { ProviderType } from 'gql/graphql';
 
 import OrgList from './OrgList';
 

--- a/packages/console/src/orgs/types.ts
+++ b/packages/console/src/orgs/types.ts
@@ -1,4 +1,4 @@
-import { ProviderType } from '@automa/common';
+import { ProviderType } from 'gql/graphql';
 
 export type Org = {
   id: number;

--- a/packages/console/src/orgs/views/OrgIntegrations/OrgIntegrations.tsx
+++ b/packages/console/src/orgs/views/OrgIntegrations/OrgIntegrations.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from 'react';
 import { useQuery } from '@apollo/client';
 
-import { IntegrationType } from '@automa/common';
-
+import { IntegrationType } from 'gql/graphql';
 import { Flex, Loader } from 'shared';
 import { objectKeys } from 'utils';
 

--- a/packages/console/src/repos/components/RepoOnboarding/RepoOnboarding.stories.tsx
+++ b/packages/console/src/repos/components/RepoOnboarding/RepoOnboarding.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
+import { ProviderType } from 'gql/graphql';
 
 import RepoOnboarding from './RepoOnboarding';
 

--- a/packages/console/src/repos/components/RepoOnboarding/RepoOnboarding.tsx
+++ b/packages/console/src/repos/components/RepoOnboarding/RepoOnboarding.tsx
@@ -2,8 +2,7 @@ import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowUpRight } from '@phosphor-icons/react';
 
-import { ProviderType } from '@automa/common';
-
+import { ProviderType } from 'gql/graphql';
 import { Flex, Tooltip, Typography } from 'shared';
 
 import GithubLogo from 'assets/logos/github.svg?react';

--- a/packages/console/src/tasks/components/Task/Task.stories.tsx
+++ b/packages/console/src/tasks/components/Task/Task.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType, TaskItemType, TaskState } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { ProviderType, TaskItemType, TaskState } from 'gql/graphql';
 
 import { USER_AVATAR_FRAGMENT } from 'users';
 

--- a/packages/console/src/tasks/components/Task/Task.tsx
+++ b/packages/console/src/tasks/components/Task/Task.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { UserCircle } from '@phosphor-icons/react';
 import { format } from 'date-fns';
 
-import { TaskItemType } from '@automa/common';
-
 import { getFragment } from 'gql';
+import { TaskItemType } from 'gql/graphql';
 import { Avatar, Flex, Tooltip, Typography } from 'shared';
 
 import { UserAvatar } from 'users';

--- a/packages/console/src/tasks/components/TaskItem/TaskItem.stories.tsx
+++ b/packages/console/src/tasks/components/TaskItem/TaskItem.stories.tsx
@@ -1,14 +1,13 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { sub } from 'date-fns';
 
+import { makeFragmentData } from 'gql';
 import {
   ProviderType,
   TaskActivityType,
   TaskItemType,
   TaskState,
-} from '@automa/common';
-
-import { makeFragmentData } from 'gql';
+} from 'gql/graphql';
 
 import { USER_AVATAR_FRAGMENT } from 'users';
 

--- a/packages/console/src/tasks/components/TaskItem/TaskItem.tsx
+++ b/packages/console/src/tasks/components/TaskItem/TaskItem.tsx
@@ -9,9 +9,8 @@ import {
 } from '@phosphor-icons/react';
 import { format, formatDistanceToNow } from 'date-fns';
 
-import { IntegrationType, TaskItemType } from '@automa/common';
-
 import { getFragment } from 'gql';
+import { IntegrationType, TaskItemType } from 'gql/graphql';
 import { Anchor, Avatar, Flex, Tooltip, Typography } from 'shared';
 
 import { USER_AVATAR_FRAGMENT, UserAvatar } from 'users';

--- a/packages/console/src/tasks/components/TaskItem/utils.tsx
+++ b/packages/console/src/tasks/components/TaskItem/utils.tsx
@@ -1,8 +1,6 @@
 import React, { FC, ReactNode, SVGProps } from 'react';
 
-import { IntegrationType, ProviderType } from '@automa/common';
-
-import { TaskItemFragment } from 'gql/graphql';
+import { IntegrationType, ProviderType, TaskItemFragment } from 'gql/graphql';
 import { Typography } from 'shared';
 
 import GithubLogo from 'assets/logos/github.svg?react';

--- a/packages/console/src/tasks/components/TaskItemBadge/TaskItemBadge.stories.tsx
+++ b/packages/console/src/tasks/components/TaskItemBadge/TaskItemBadge.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { IntegrationType, ProviderType, TaskItemType } from '@automa/common';
+import { IntegrationType, ProviderType, TaskItemType } from 'gql/graphql';
 
 import TaskItemBadge from './TaskItemBadge';
 

--- a/packages/console/src/tasks/components/TaskItemBadge/utils.tsx
+++ b/packages/console/src/tasks/components/TaskItemBadge/utils.tsx
@@ -1,8 +1,11 @@
 import React, { ReactNode } from 'react';
 
-import { IntegrationType, ProviderType, TaskItemType } from '@automa/common';
-
-import { TaskItemFragment } from 'gql/graphql';
+import {
+  IntegrationType,
+  ProviderType,
+  TaskItemFragment,
+  TaskItemType,
+} from 'gql/graphql';
 import { Flex, Typography } from 'shared';
 
 import GithubLogo from 'assets/logos/github.svg?react';

--- a/packages/console/src/tasks/components/TaskScheduled/TaskScheduled.stories.tsx
+++ b/packages/console/src/tasks/components/TaskScheduled/TaskScheduled.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType, TaskState } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { ProviderType, TaskState } from 'gql/graphql';
 
 import { TASK_FRAGMENT } from '../Task';
 import { TASK_ITEM_FRAGMENT } from '../TaskItem';

--- a/packages/console/src/tasks/components/TaskScheduled/TaskScheduled.tsx
+++ b/packages/console/src/tasks/components/TaskScheduled/TaskScheduled.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { format } from 'date-fns';
 
-import { TaskItemType } from '@automa/common';
-
 import { getFragment } from 'gql';
+import { TaskItemType } from 'gql/graphql';
 import { Avatar, Flex, Tooltip, Typography } from 'shared';
 
 import { TASK_FRAGMENT } from '../Task';

--- a/packages/console/src/tasks/components/TaskStateIcon/TaskStateIcon.stories.tsx
+++ b/packages/console/src/tasks/components/TaskStateIcon/TaskStateIcon.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { TaskState } from '@automa/common';
+import { TaskState } from 'gql/graphql';
 
 import TaskStateIcon from './TaskStateIcon';
 

--- a/packages/console/src/tasks/components/TaskStateIcon/TaskStateIcon.tsx
+++ b/packages/console/src/tasks/components/TaskStateIcon/TaskStateIcon.tsx
@@ -8,8 +8,7 @@ import {
   XCircle,
 } from '@phosphor-icons/react';
 
-import { TaskState } from '@automa/common';
-
+import { TaskState } from 'gql/graphql';
 import { Tooltip, Typography } from 'shared';
 
 import { TaskStateIconProps } from './types';

--- a/packages/console/src/tasks/components/TaskStateIcon/types.ts
+++ b/packages/console/src/tasks/components/TaskStateIcon/types.ts
@@ -1,4 +1,4 @@
-import { TaskState } from '@automa/common';
+import { TaskState } from 'gql/graphql';
 
 export interface TaskStateIconProps {
   state: TaskState;

--- a/packages/console/src/tasks/utils.ts
+++ b/packages/console/src/tasks/utils.ts
@@ -1,6 +1,4 @@
-import { IntegrationType, ProviderType } from '@automa/common';
-
-import { TaskItemFragment } from 'gql/graphql';
+import { IntegrationType, ProviderType, TaskItemFragment } from 'gql/graphql';
 
 export const getTaskItemUser = (data?: {
   integration?: IntegrationType;

--- a/packages/console/src/tasks/views/TaskCreate/TaskCreate.tsx
+++ b/packages/console/src/tasks/views/TaskCreate/TaskCreate.tsx
@@ -4,9 +4,10 @@ import { useMutation } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
-import { TaskMessageInput, taskMessageSchema } from '@automa/common';
+import { taskMessageSchema } from '@automa/common';
 
 import { getFragment } from 'gql';
+import { TaskMessageInput } from 'gql/graphql';
 import { Button, Flex, Textarea, toast, Typography } from 'shared';
 
 import { TASK_FRAGMENT } from 'tasks';

--- a/packages/console/src/users/components/UserAvatar/UserAvatar.stories.tsx
+++ b/packages/console/src/users/components/UserAvatar/UserAvatar.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { ProviderType } from 'gql/graphql';
 
 import UserAvatar from './UserAvatar';
 

--- a/packages/console/src/users/components/UserNavbar/UserNavbar.stories.tsx
+++ b/packages/console/src/users/components/UserNavbar/UserNavbar.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { ProviderType } from '@automa/common';
-
 import { makeFragmentData } from 'gql';
+import { ProviderType } from 'gql/graphql';
 
 import { USER_AVATAR_FRAGMENT } from '../UserAvatar';
 

--- a/packages/console/src/users/views/UserSettingsConnections/utils.ts
+++ b/packages/console/src/users/views/UserSettingsConnections/utils.ts
@@ -1,6 +1,6 @@
 import { FC, SVGProps } from 'react';
 
-import { ProviderType } from '@automa/common';
+import { ProviderType } from 'gql/graphql';
 
 import GithubLogo from 'assets/logos/github.svg?react';
 import GitlabLogo from 'assets/logos/gitlab.svg?react';

--- a/packages/console/src/users/views/UserSettingsGeneral/UserSettingsGeneral.tsx
+++ b/packages/console/src/users/views/UserSettingsGeneral/UserSettingsGeneral.tsx
@@ -3,9 +3,10 @@ import { useMutation, useQuery } from '@apollo/client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 
-import { UserUpdateInput, userUpdateSchema } from '@automa/common';
+import { userUpdateSchema } from '@automa/common';
 
 import { getFragment } from 'gql';
+import { UserUpdateInput } from 'gql/graphql';
 import { Button, Flex, Input, toast, Typography } from 'shared';
 
 import { ME_QUERY, ME_QUERY_FRAGMENT, USER_AVATAR_FRAGMENT } from 'users';

--- a/packages/console/src/utils.ts
+++ b/packages/console/src/utils.ts
@@ -1,6 +1,6 @@
-import { ProviderType } from '@automa/common';
-
 import { environment } from 'env';
+
+import { ProviderType } from 'gql/graphql';
 
 export const appName = (name: string = 'automa') =>
   `${name}${environment === 'production' ? '' : `-${environment}`}`;

--- a/packages/console/src/views/DeepLink/DeepLink.test.tsx
+++ b/packages/console/src/views/DeepLink/DeepLink.test.tsx
@@ -1,8 +1,8 @@
 import { expect } from 'vitest';
 
-import { ProviderType } from '@automa/common';
-
 import { mockedNavigate, render } from 'tests';
+
+import { ProviderType } from 'gql/graphql';
 
 import DeepLink from './DeepLink';
 


### PR DESCRIPTION
Right now, importing a db type in BE is suggesting two places
`@automa/common` & `@automa/prisma`. And importing a graphql type
in FE is suggesting `@automa/common` & `gql/graphql`.

This PR removes the ambiguity and provides both BE and FE with only
one place to import the types from.
